### PR TITLE
#34 Implement getting claim by its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JWT
 
 [![Lines-of-Code](https://tokei.rs/b1/github/ilyalisov/jwt)](https://github.com/ilyalisov/jwt)
-[![Hits-of-Code](https://hitsofcode.com/github/ilyalisov/jwt?branch=main)](https://hitsofcode.com/github/ilyalisov/jwt/view?branch=main)
+[![Hits-of-Code](https://hitsofcode.com/github/ilyalisov/jwt?branch=master)](https://hitsofcode.com/github/ilyalisov/jwt/view?branch=master)
 [![mvn](https://github.com/ilyalisov/jwt/actions/workflows/maven-build.yml/badge.svg)](https://github.com/ilyalisov/jwt/actions/workflows/maven-build.yml)
 
 [![codecov](https://codecov.io/gh/IlyaLisov/jwt/graph/badge.svg?token=OJR6TFQ2qr)](https://codecov.io/gh/IlyaLisov/jwt)

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ object.
 
 ```java
 public class Main {
-    public void main(String[] args) {
+    public static void main(String[] args) {
         String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
         Map<String, Object> claims = tokenService.claims(token);

--- a/src/main/java/io/github/ilyalisov/jwt/service/PersistentTokenServiceImpl.java
+++ b/src/main/java/io/github/ilyalisov/jwt/service/PersistentTokenServiceImpl.java
@@ -172,6 +172,20 @@ public class PersistentTokenServiceImpl implements PersistentTokenService {
     }
 
     @Override
+    public Object claim(
+            final String token,
+            final String key
+    ) {
+        Jws<Claims> claims = Jwts
+                .parser()
+                .verifyWith(this.key)
+                .build()
+                .parseSignedClaims(token);
+        return claims.getPayload()
+                .get(key);
+    }
+
+    @Override
     public boolean invalidate(
             final String token
     ) {

--- a/src/main/java/io/github/ilyalisov/jwt/service/TokenService.java
+++ b/src/main/java/io/github/ilyalisov/jwt/service/TokenService.java
@@ -87,4 +87,16 @@ public interface TokenService {
             String token
     );
 
+    /**
+     * Returns claim of JWT token by its key.
+     *
+     * @param token JWT token
+     * @param key   key of claim
+     * @return value of claim or null if there is no value
+     */
+    Object claim(
+            String token,
+            String key
+    );
+
 }

--- a/src/main/java/io/github/ilyalisov/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/io/github/ilyalisov/jwt/service/TokenServiceImpl.java
@@ -138,4 +138,18 @@ public class TokenServiceImpl implements TokenService {
         return new HashMap<>(claims.getPayload());
     }
 
+    @Override
+    public Object claim(
+            final String token,
+            final String key
+    ) {
+        Jws<Claims> claims = Jwts
+                .parser()
+                .verifyWith(this.key)
+                .build()
+                .parseSignedClaims(token);
+        return claims.getPayload()
+                .get(key);
+    }
+
 }

--- a/src/test/java/io/github/ilyalisov/jwt/service/PersistentTokenServiceImplTests.java
+++ b/src/test/java/io/github/ilyalisov/jwt/service/PersistentTokenServiceImplTests.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PersistentTokenServiceImplTests {
@@ -200,6 +201,58 @@ class PersistentTokenServiceImplTests {
         assertNotNull(claims);
         assertEquals("value1", claims.get("key1"));
         assertEquals(123, claims.get("key2"));
+    }
+
+
+    @Test
+    void shouldReturnCorrectClaimValue() {
+        String subject = "testSubject";
+        String type = "any";
+        Duration duration = Duration.ofMinutes(30);
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "key1"
+        );
+        assertNotNull(claim);
+        assertEquals("value1", claim);
+    }
+
+    @Test
+    void shouldReturnNull() {
+        String subject = "testSubject";
+        String type = "any";
+        Duration duration = Duration.ofMinutes(30);
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "notExistingKey"
+        );
+        assertNull(claim);
     }
 
     @Test

--- a/src/test/java/io/github/ilyalisov/jwt/service/TokenServiceImplTests.java
+++ b/src/test/java/io/github/ilyalisov/jwt/service/TokenServiceImplTests.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TokenServiceImplTests {
@@ -174,6 +175,57 @@ class TokenServiceImplTests {
         assertNotNull(claims);
         assertEquals("value1", claims.get("key1"));
         assertEquals(123, claims.get("key2"));
+    }
+
+    @Test
+    void shouldReturnCorrectClaimValue() {
+        String subject = "testSubject";
+        String type = "any";
+        Duration duration = Duration.ofMinutes(30);
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "key1"
+        );
+        assertNotNull(claim);
+        assertEquals("value1", claim);
+    }
+
+    @Test
+    void shouldReturnNull() {
+        String subject = "testSubject";
+        String type = "any";
+        Duration duration = Duration.ofMinutes(30);
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("key1", "value1");
+        customClaims.put("key2", 123);
+
+        TokenParameters params = TokenParameters.builder(
+                        subject,
+                        type,
+                        duration
+                )
+                .claims(customClaims)
+                .build();
+
+        String token = tokenService.create(params);
+        Object claim = tokenService.claim(
+                token,
+                "notExistingKey"
+        );
+        assertNull(claim);
     }
 
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the JWT token service by adding a method to retrieve a claim value by its key. 

### Detailed summary
- Added a `claim` method to retrieve a claim value by key in `TokenService`
- Implemented the `claim` method in `TokenServiceImpl` and `PersistentTokenServiceImpl`
- Added corresponding tests for the `claim` method in both implementations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->